### PR TITLE
Support earlier Python versions and move requirements to pyproject.toml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,24 +2,14 @@ name: Pytest
 
 on:
   push:
-    branches:
-      - 'main'
-    paths-ignore:
-      # Do not run if only the documentation has been changed
-      - 'docs/**'
-      - '**/*.md'
   pull_request:
-    paths-ignore:
-      # Do not run if only the documentation has been changed
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.7", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -29,9 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r examples/requirements.txt
         pip install .
 
-    - name: Analysing the code with pylint
-      run: |
-        pytest 
+    - name: Run tests
+      run: pytest 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install .[test]
 
     - name: Run tests
-      run: pytest 
+      run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A toolbox to factorize some code utilities across various projects.
 
 ## Install
 
-To install the package, type ```python3 -m pip install pyntb``` in a terminal.
+The package requires Python 3.7 or above and is available on PyPI:
+```
+python3 -m pip install pyntb
+```
 
 ## Content
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ The package requires Python 3.7 or above and is available on PyPI:
 python3 -m pip install pyntb
 ```
 
+The optional dependencies used in the examples in the Github repository can be installed at the same time by typing instead:
+```
+python3 -m pip install pyntb[examples]
+```
+
 ## Content
 
 - `geoutils`

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,0 @@
-matplotlib
-pytest
-scikit-learn
-wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,11 @@ classifiers = [
 dependencies = [
     "numpy",
     "scipy",
-    "pylint",
 ]
 
 [project.optional-dependencies]
 examples = ["matplotlib", "scikit-learn"]
-test = ["pytest", "scikit-learn"]
+test = ["pytest", "scikit-learn", "pylint"]
 
 [project.urls]
 "Homepage" = "https://github.com/eurobios-mews-labs/pyntb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A toolbox to factorize some code utilities across various projects."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -20,6 +20,10 @@ dependencies = [
     "scipy",
     "pylint",
 ]
+
+[project.optional-dependencies]
+examples = ["matplotlib", "scikit-learn"]
+test = ["pytest", "scikit-learn"]
 
 [project.urls]
 "Homepage" = "https://github.com/eurobios-mews-labs/pyntb"

--- a/src/pyntb/optimize.py
+++ b/src/pyntb/optimize.py
@@ -15,11 +15,11 @@
 
 """Misc. numeric functions."""
 
+from __future__ import annotations  # Type annotations for Python 3.7 and 3.8
+
 import numpy as np
 from scipy._lib._util import _asarray_validated
 from scipy._lib._util import _lazywhere
-from scipy.optimize._minpack_py import _del2
-from scipy.optimize._minpack_py import _relerr
 
 
 def bisect_v(fun: callable, a: float, b: float, shape: tuple[int, ...], tol=1.0E-06,
@@ -61,6 +61,12 @@ def bisect_v(fun: callable, a: float, b: float, shape: tuple[int, ...], tol=1.0E
         print(f"Bisection max err (abs) : {np.max(err):.2E}; count={count}")
     return x, err
 
+
+def _del2(p0, p1, d):
+    return p0 - np.square(p1 - p0) / d
+
+def _relerr(actual, desired):
+    return (actual - desired) / desired
 
 def _fixed_point_helper(func, x0, args, xtol, maxiter, use_accel):
     """Almost copied from scipy.optimize._minpack_py.py.

--- a/src/pyntb/polynomial.py
+++ b/src/pyntb/polynomial.py
@@ -15,6 +15,8 @@
 
 """Analytical root finding with array inputs."""
 
+from __future__ import annotations  # Type annotations for Python 3.7 and 3.8
+
 from typing import Union
 
 import numpy as np


### PR DESCRIPTION
- Add support for Python 3.7 to 3.9 (pyntb is required by thermohl, which according to its own pyproject.toml supports Python 3.7 or above)
- Update Github Action to test on an old version of Python (3.7) and a recent one (3.12).
- Move optional requirements to pyproject.toml